### PR TITLE
edge: Fix bug in DestNodeID referencing e.Source

### DIFF
--- a/edge.go
+++ b/edge.go
@@ -55,7 +55,7 @@ func (e Edge) SourceNodeID() uint64 {
 
 // DestNodeID returns edge destination node ID
 func (e Edge) DestNodeID() uint64 {
-	if e.Source != nil {
+	if e.Destination != nil {
 		return e.Destination.ID
 	} else {
 		return e.destNodeID


### PR DESCRIPTION
Fixing a NPE in our graph code, which was caused by the invalid nil check on e.Source rather than e.Destination in DestNodeID().

Also adding a new unit test to verify this fix, as well as query support for multiple edges in a response query.